### PR TITLE
feat: AppInstanceStreamingConfiguration

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,6 +2,63 @@
 
 ## Constructs <a name="Constructs" id="constructs"></a>
 
+### AppInstanceStreamingConfigurations <a name="cdk-amazon-chime-resources.AppInstanceStreamingConfigurations" id="cdkamazonchimeresourcesappinstancestreamingconfigurations"></a>
+
+#### Initializers <a name="cdk-amazon-chime-resources.AppInstanceStreamingConfigurations.Initializer" id="cdkamazonchimeresourcesappinstancestreamingconfigurationsinitializer"></a>
+
+```typescript
+import { AppInstanceStreamingConfigurations } from 'cdk-amazon-chime-resources'
+
+new AppInstanceStreamingConfigurations(scope: Construct, id: string, props: StreamingConfigurationProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`scope`](#cdkamazonchimeresourcesappinstancestreamingconfigurationsparameterscope)<span title="Required">*</span> | [`constructs.Construct`](#constructs.Construct) | *No description.* |
+| [`id`](#cdkamazonchimeresourcesappinstancestreamingconfigurationsparameterid)<span title="Required">*</span> | `string` | *No description.* |
+| [`props`](#cdkamazonchimeresourcesappinstancestreamingconfigurationsparameterprops)<span title="Required">*</span> | [`cdk-amazon-chime-resources.StreamingConfigurationProps`](#cdk-amazon-chime-resources.StreamingConfigurationProps) | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="cdk-amazon-chime-resources.AppInstanceStreamingConfigurations.parameter.scope" id="cdkamazonchimeresourcesappinstancestreamingconfigurationsparameterscope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk-amazon-chime-resources.AppInstanceStreamingConfigurations.parameter.id" id="cdkamazonchimeresourcesappinstancestreamingconfigurationsparameterid"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="cdk-amazon-chime-resources.AppInstanceStreamingConfigurations.parameter.props" id="cdkamazonchimeresourcesappinstancestreamingconfigurationsparameterprops"></a>
+
+- *Type:* [`cdk-amazon-chime-resources.StreamingConfigurationProps`](#cdk-amazon-chime-resources.StreamingConfigurationProps)
+
+---
+
+
+
+#### Properties <a name="Properties" id="properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`streamingConfigs`](#cdkamazonchimeresourcesappinstancestreamingconfigurationspropertystreamingconfigs)<span title="Required">*</span> | [`cdk-amazon-chime-resources.StreamingConfig`](#cdk-amazon-chime-resources.StreamingConfig)[] | *No description.* |
+
+---
+
+##### `streamingConfigs`<sup>Required</sup> <a name="cdk-amazon-chime-resources.AppInstanceStreamingConfigurations.property.streamingConfigs" id="cdkamazonchimeresourcesappinstancestreamingconfigurationspropertystreamingconfigs"></a>
+
+```typescript
+public readonly streamingConfigs: StreamingConfig[];
+```
+
+- *Type:* [`cdk-amazon-chime-resources.StreamingConfig`](#cdk-amazon-chime-resources.StreamingConfig)[]
+
+---
+
+
 ### ChannelFlow <a name="cdk-amazon-chime-resources.ChannelFlow" id="cdkamazonchimeresourceschannelflow"></a>
 
 #### Initializers <a name="cdk-amazon-chime-resources.ChannelFlow.Initializer" id="cdkamazonchimeresourceschannelflowinitializer"></a>
@@ -1877,6 +1934,10 @@ Streaming data retention for VoiceConnector.
 
 ### StreamingConfig <a name="cdk-amazon-chime-resources.StreamingConfig" id="cdkamazonchimeresourcesstreamingconfig"></a>
 
+Props for `AppInstanceStreamingConfiguration`.
+
+See: https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_AppInstanceStreamingConfiguration.html
+
 #### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
 
 ```typescript
@@ -1915,6 +1976,55 @@ public readonly resourceArn: string;
 - *Type:* `string`
 
 The resource ARN of a Kinesis Stream.
+
+---
+
+### StreamingConfigurationProps <a name="cdk-amazon-chime-resources.StreamingConfigurationProps" id="cdkamazonchimeresourcesstreamingconfigurationprops"></a>
+
+Props for `PutAppInstanceStreamingConfigurations`.
+
+See: https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_PutAppInstanceStreamingConfigurations.html
+
+#### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
+
+```typescript
+import { StreamingConfigurationProps } from 'cdk-amazon-chime-resources'
+
+const streamingConfigurationProps: StreamingConfigurationProps = { ... }
+```
+
+#### Properties <a name="Properties" id="properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`appInstanceArn`](#cdkamazonchimeresourcesstreamingconfigurationpropspropertyappinstancearn)<span title="Required">*</span> | `string` | The ARN of the App Instance. |
+| [`streamingConfigs`](#cdkamazonchimeresourcesstreamingconfigurationpropspropertystreamingconfigs)<span title="Required">*</span> | [`cdk-amazon-chime-resources.StreamingConfig`](#cdk-amazon-chime-resources.StreamingConfig)[] | The AppInstanceStreamingConfigurations. |
+
+---
+
+##### `appInstanceArn`<sup>Required</sup> <a name="cdk-amazon-chime-resources.StreamingConfigurationProps.property.appInstanceArn" id="cdkamazonchimeresourcesstreamingconfigurationpropspropertyappinstancearn"></a>
+
+```typescript
+public readonly appInstanceArn: string;
+```
+
+- *Type:* `string`
+- *Default:* None
+
+The ARN of the App Instance.
+
+---
+
+##### `streamingConfigs`<sup>Required</sup> <a name="cdk-amazon-chime-resources.StreamingConfigurationProps.property.streamingConfigs" id="cdkamazonchimeresourcesstreamingconfigurationpropspropertystreamingconfigs"></a>
+
+```typescript
+public readonly streamingConfigs: StreamingConfig[];
+```
+
+- *Type:* [`cdk-amazon-chime-resources.StreamingConfig`](#cdk-amazon-chime-resources.StreamingConfig)[]
+- *Default:* None
+
+The AppInstanceStreamingConfigurations.
 
 ---
 

--- a/example/lib/messaging-resource-example.ts
+++ b/example/lib/messaging-resource-example.ts
@@ -86,12 +86,23 @@ export class MessagingExample extends Stack {
       encryption: kinesis.StreamEncryption.MANAGED,
     });
 
-    appInstance.streaming([
+    // both of the following add streaming config, but will override each other, can use either
+    new chime.AppInstanceStreamingConfigurations(this, 'streamingConfig',
       {
-        appInstanceDataType: chime.AppInstanceDataType.CHANNEL,
-        resourceArn: kinesisStream.streamArn,
-      },
-    ]);
+          appInstanceArn: appInstance.appInstanceArn,
+          streamingConfigs: [{
+          appInstanceDataType: chime.AppInstanceDataType.CHANNEL,
+          resourceArn: kinesisStream.streamArn,
+        }],
+      }
+    );
+
+    // appInstance.streaming([
+    //   {
+    //     appInstanceDataType: chime.AppInstanceDataType.CHANNEL,
+    //     resourceArn: kinesisStream.streamArn,
+    //   },
+    // ]);
 
     appInstance.retention(2);
 

--- a/example/src/streamingHandler.py
+++ b/example/src/streamingHandler.py
@@ -1,0 +1,11 @@
+import os
+import json
+
+
+def lambda_handler(event, context):
+    json_region = os.environ["AWS_REGION"]
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"Region ": json_region}),
+    }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './messaging/appInstance';
 export * from './messaging/channelFlow';
 export * from './messaging/instanceAdmin';
 export * from './messaging/instanceUser';
+export * from './messaging/instanceStreamingConfiguration';

--- a/src/messaging/appInstance.ts
+++ b/src/messaging/appInstance.ts
@@ -8,6 +8,10 @@ export enum AppInstanceDataType {
   CHANNELMESSAGE = 'ChannelMessage',
 }
 
+/**
+ * Props for `AppInstanceStreamingConfiguration`.
+ * See: https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_AppInstanceStreamingConfiguration.html
+ */
 export interface StreamingConfig {
   /**
    * The type of data to be streamed.

--- a/src/messaging/instanceStreamingConfiguration.ts
+++ b/src/messaging/instanceStreamingConfiguration.ts
@@ -1,0 +1,50 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { StreamingConfig } from './appInstance';
+import { MessagingResources } from './messagingCustomResources';
+
+/**
+ * Props for `PutAppInstanceStreamingConfigurations`.
+ * See: https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_PutAppInstanceStreamingConfigurations.html
+ */
+export interface StreamingConfigurationProps {
+  /**
+   * The ARN of the App Instance
+   *
+   * @default - None
+   */
+  readonly appInstanceArn: string;
+
+  /**
+   * The AppInstanceStreamingConfigurations
+   *
+   * @default - None
+   */
+  readonly streamingConfigs: Array<StreamingConfig>;
+}
+
+export class AppInstanceStreamingConfigurations extends Construct {
+  public readonly streamingConfigs: Array<StreamingConfig>;
+
+  constructor(scope: Construct, id: string, props: StreamingConfigurationProps) {
+    super(scope, id);
+
+    const { streamingConfigs, appInstanceArn } = props;
+
+    const uid: string = cdk.Names.uniqueId(this);
+    new MessagingResources(
+      this,
+      'AppInstanceStreamingConfiguration',
+      {
+        resourceType: 'StreamingConfig',
+        uid: uid,
+        properties: {
+          appInstanceArn: appInstanceArn,
+          streamingConfigs: streamingConfigs,
+        },
+      },
+    );
+
+    this.streamingConfigs = streamingConfigs;
+  }
+}

--- a/src/messaging/messagingCustomResources.ts
+++ b/src/messaging/messagingCustomResources.ts
@@ -15,7 +15,8 @@ export interface MessagingResourceProps extends cdk.ResourceProps {
     | 'AppInstanceUser'
     | 'AppInstanceAdmin'
     | 'DataRetention'
-    | 'StreamingConfig';
+    | 'StreamingConfig'
+    | 'AppInstanceStreamingConfigurations';
   readonly uid: string;
 }
 

--- a/test/messaging/instanceStreamingConfiguration.test.ts
+++ b/test/messaging/instanceStreamingConfiguration.test.ts
@@ -1,0 +1,21 @@
+import * as cdk from 'aws-cdk-lib';
+import { AppInstanceDataType, AppInstanceStreamingConfigurations } from '../../lib';
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, 'testing-stack', {
+  env: {
+    region: 'us-east-1',
+    account: '1234567890123',
+  },
+});
+
+test('InstanceStreamingConfig', () => {
+  new AppInstanceStreamingConfigurations(stack, 'BasicStreamingConfig', {
+    appInstanceArn: 'appInstanceArn',
+    streamingConfigs: [{
+      appInstanceDataType: AppInstanceDataType.CHANNEL,
+      resourceArn: 'resourceArn',
+    }],
+  });
+});
+


### PR DESCRIPTION
Add support for creating AppInstanceStreamingConfiguration independent of app instance.  Needed if app instance already exists; ex it is initialized in different stack.  You could previously (and still can) after this commit set it via `.streaming()` as a method on an app instance construct.  This adds the following: 

```
    new chime.AppInstanceStreamingConfigurations(this, 'streamingConfig',
          appInstanceArn: appInstance.appInstanceArn,
          streamingConfigs: [{
          appInstanceDataType: chime.AppInstanceDataType.CHANNEL,
          resourceArn: kinesisStream.streamArn,
        }],
      }
    );
```

The `.streaming` is probably generally the more useful one, but the above is needed where app instance is previously created or created in a network stack

Tested by testing the messagingSession, and then describing and seeing the messaging session 

```
yarn cdk deploy MessagingResources
...
 aws chime get-app-instance-streaming-configurations --app-instance-arn
```